### PR TITLE
Fix use of hash value type

### DIFF
--- a/lib/OrderedHash.pm6
+++ b/lib/OrderedHash.pm6
@@ -1,7 +1,7 @@
-unit role OrderedHash[::T \Type = Any, :@keys = flat("0".."9", "A".."Z", "a".."z")] does Associative;
-has Mu:U    $!of    = Type;
+unit role OrderedHash[::T = Any, :@keys = flat("0".."9", "A".."Z", "a".."z")] does Associative;
+has Mu:U    $!of    = T;
 has Str     @!keys  = @keys;
-has T       @!values is default(Type);
+has T       @!values is default(T);
 has UInt    %!map   = @keys.kv.reverse;
 
 method STORE(*@pairs, :$initialize --> OrderedHash:D) {
@@ -12,6 +12,8 @@ method STORE(*@pairs, :$initialize --> OrderedHash:D) {
 }
 
 method !index(Str() \key where any @!keys --> UInt) { %!map{key} }
+
+method of { $!of }
 
 method elems { self.keys.elems }
 

--- a/t/01-basic.t
+++ b/t/01-basic.t
@@ -2,6 +2,21 @@ use v6.c;
 use Test;
 use OrderedHash;
 
-pass "replace me";
+plan 2;
+
+sub cmp-default(%h is raw, Mu \default-type) is test-assertion {
+    subtest "value type is " ~ default-type.^name => {
+        plan 3;
+        cmp-ok %h.of, &[===], default-type, "default value type";
+        cmp-ok %h<a>, &[===], default-type, "referencing unset key returns default";
+        cmp-ok %h<a>:delete, &[===], default-type, "delete non-existing key returns default";
+    }
+}
+
+my %oh does OrderedHash;
+cmp-default %oh, Any;
+
+my %oo does OrderedHash[Str];
+cmp-default %oo, Str;
 
 done-testing;


### PR DESCRIPTION
First of all, don't use positional parameter of role's signature where it is used at compile-time. In particular, `is default` would then unconditionally be set to `Mu` because this is what is the positional's value when role body is compiled.

Second, override `of` method because the default one relies on hash own container descriptor and knows nothing about role's value type.